### PR TITLE
feat(ui): tighten Neta card top spacing and align judge selection docs to p=4/7

### DIFF
--- a/.changeset/empty-symbols-rush.md
+++ b/.changeset/empty-symbols-rush.md
@@ -1,0 +1,5 @@
+---
+'yonokomae': major
+---
+
+BREAKING CHANGE: Judgeの判定結果をWinnerからVerdictに変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,17 @@
 ### Breaking Changes
 
 - refactor(core)!: migrate `determineWinner` to return a structured
-    `Verdict` and remove the legacy `Winner` alias entirely. The literal union
-    for the winner field is inlined (`'YONO' | 'KOMAE' | 'DRAW'`). This impacts
-    all call sites and implementations.
+  `Verdict` and remove the legacy `Winner` alias entirely. The literal union
+  for the winner field is inlined (`'YONO' | 'KOMAE' | 'DRAW'`). This impacts
+  all call sites and implementations.
     - API: `JudgementRepository.determineWinner` now returns `Promise<Verdict>`
-        instead of `Promise<Winner>`.
+      instead of `Promise<Winner>`.
     - Call sites: read `verdict.winner` instead of using a raw string.
     - Implementations/Mocks: return a `Verdict` object with `winner` and
-        a valid `reason` (e.g. `'power'`).
+      a valid `reason` (e.g. `'power'`).
     - Tests: expectations updated to assert `verdict.winner`.
     - Docs: DEVELOPMENT_EN.md updated with migration notes and DEVELOPMENT_JA.md
-        synced.
+      synced.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 ## Unreleased
 
-### Minor Changes
+### Breaking Changes
+
+- refactor(core)!: migrate `determineWinner` to return a structured
+    `Verdict` and remove the legacy `Winner` alias entirely. The literal union
+    for the winner field is inlined (`'YONO' | 'KOMAE' | 'DRAW'`). This impacts
+    all call sites and implementations.
+    - API: `JudgementRepository.determineWinner` now returns `Promise<Verdict>`
+        instead of `Promise<Winner>`.
+    - Call sites: read `verdict.winner` instead of using a raw string.
+    - Implementations/Mocks: return a `Verdict` object with `winner` and
+        a valid `reason` (e.g. `'power'`).
+    - Tests: expectations updated to assert `verdict.winner`.
+    - Docs: DEVELOPMENT_EN.md updated with migration notes and DEVELOPMENT_JA.md
+        synced.
+
+### Enhancements
 
 - feat(usage): Add UsageExamples and UserVoices components with interactive displays
 - feat(export): Add TSV export functionality for usage examples and user voices data

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -22,7 +22,9 @@ test.describe('Accessibility (axe-core)', () => {
     expectNoA11yBlockers,
   }) => {
     await page.goto('/');
-    await page.getByText('DEMO', { exact: true }).click();
+    // Confirm the currently highlighted mode via keyboard
+    await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+    await page.keyboard.press('Enter');
     await expect(page.getByRole('button', { name: 'Battle' })).toBeVisible();
 
     const results = await analyzeA11y();
@@ -35,7 +37,9 @@ test.describe('Accessibility (axe-core)', () => {
     expectNoA11yBlockers,
   }) => {
     await page.goto('/');
-    await page.getByText('DEMO', { exact: true }).click();
+    // Confirm the currently highlighted mode via keyboard
+    await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+    await page.keyboard.press('Enter');
     await page.getByRole('button', { name: 'Battle' }).click();
 
     const results = await analyzeA11y();

--- a/e2e/battle-container.spec.ts
+++ b/e2e/battle-container.spec.ts
@@ -40,7 +40,8 @@ test.describe('Battle container visibility', () => {
     await page.goto('/');
 
     // select mode (game start)
-    await page.getByText('DEMO', { exact: true }).click();
+    await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+    await page.keyboard.press('Enter');
     await page.getByRole('button', { name: 'Battle' }).click();
 
     // test: one container and its internals exist
@@ -56,7 +57,8 @@ test.describe('Battle container visibility', () => {
     await page.goto('/');
 
     // select mode (game start)
-    await page.getByText('DEMO', { exact: true }).click();
+    await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+    await page.keyboard.press('Enter');
 
     // generate first
     await page.getByRole('button', { name: 'Battle' }).click();
@@ -80,7 +82,8 @@ test.describe('Battle container visibility', () => {
     await page.goto('/');
 
     // select mode (game start)
-    await page.getByText('DEMO', { exact: true }).click();
+    await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+    await page.keyboard.press('Enter');
 
     // click Battle 10 times, verifying counts increment each time
     for (let i = 1; i <= 10; i++) {
@@ -107,7 +110,8 @@ test.describe('Battle container visibility', () => {
       await page.goto('/');
 
       // select mode (game start)
-      await page.getByText('DEMO', { exact: true }).click();
+      await page.getByRole('radiogroup', { name: 'Play modes' }).focus();
+      await page.keyboard.press('Enter');
 
       const battleBtn = page.getByRole('button', { name: 'Battle' });
 

--- a/mock-api/server.ts
+++ b/mock-api/server.ts
@@ -38,7 +38,15 @@ const server = http.createServer((req, res) => {
   }
   if (req.url.startsWith('/api/battle/judgement')) {
     res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify('DRAW'));
+    res.end(
+      JSON.stringify({
+        winner: 'DRAW',
+        reason: 'api',
+        rng: 0.5,
+        judgeCode: 'API',
+        powerDiff: 0,
+      }),
+    );
     return;
   }
   res.writeHead(404);

--- a/src/components/battle/Judge.tsx
+++ b/src/components/battle/Judge.tsx
@@ -4,7 +4,6 @@ import type { Battle } from '@/types/types';
 import { useJudgement } from '@/hooks/use-judgement';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import type { Winner } from '@/yk/repo/core/repositories';
 import type { PlayMode } from '@/yk/play-mode';
 import { prefersReducedMotion } from '@/lib/reduced-motion';
 
@@ -70,7 +69,7 @@ export const JudgeCard: FC<JudgeCardProps> = ({
               <span className="text-destructive">Failed</span>
             )}
             {judgement.status === 'success' &&
-              (revealed ? <WinnerBadge winner={judgement.data} /> : '…')}
+              (revealed ? <WinnerBadge winner={judgement.data.winner} /> : '…')}
           </div>
         </div>
       </CardContent>
@@ -78,7 +77,11 @@ export const JudgeCard: FC<JudgeCardProps> = ({
   );
 };
 
-function WinnerBadge({ winner }: { winner: Winner }) {
+function WinnerBadge({
+  winner,
+}: {
+  winner: import('@/yk/repo/core/repositories').Verdict['winner'];
+}) {
   switch (winner) {
     case 'YONO':
       return (

--- a/src/components/battle/Judge.tsx
+++ b/src/components/battle/Judge.tsx
@@ -54,6 +54,10 @@ export const JudgeCard: FC<JudgeCardProps> = ({
     setRevealed(false);
   }, [judgement.status, delayMs]);
 
+  // if (judgement.status === 'success') {
+  //   console.log( judgement );
+  // }
+
   return (
     <Card className="h-full min-w-0 overflow-hidden text-center gap-2 px-0 py-0">
       <CardHeader className="px-0 pt-4">

--- a/src/components/battle/Neta.tsx
+++ b/src/components/battle/Neta.tsx
@@ -306,7 +306,7 @@ export const NetaView: FC<Props> = ({
   return (
     <Card
       className={[
-        'w-full overflow-hidden',
+        'w-full overflow-hidden pt-0',
         'max-w-none',
         fullHeight ? 'h-full' : '',
       ].join(' ')}

--- a/src/hooks/use-judgement.test.tsx
+++ b/src/hooks/use-judgement.test.tsx
@@ -48,7 +48,7 @@ function Probe({ repoKind }: { repoKind: 'provided' | 'factory' }) {
   return (
     <div>
       <span data-testid="status">{j.status}</span>
-      <span data-testid="data">{j.data ?? ''}</span>
+      <span data-testid="data">{j.data ? j.data.winner : ''}</span>
       <span data-testid="error">{j.error ? 'err' : ''}</span>
       <span data-testid="repoKind">{repoKind}</span>
     </div>
@@ -68,7 +68,12 @@ describe('useJudgement', () => {
       useRepositoriesOptional as unknown as ReturnType<typeof vi.fn>
     ).mockReturnValue({
       battleReport: undefined as unknown as never,
-      judgement: { determineWinner: vi.fn(async () => 'YONO') },
+      judgement: {
+        determineWinner: vi.fn(async () => ({
+          winner: 'YONO',
+          reason: 'power',
+        })),
+      },
     });
     render(<Probe repoKind="provided" />);
     expect(screen.getByTestId('status').textContent).toBe('loading');

--- a/src/hooks/use-judgement.ts
+++ b/src/hooks/use-judgement.ts
@@ -2,14 +2,14 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Battle } from '@/types/types';
 import type { PlayMode } from '@/yk/play-mode';
 import { getJudgementRepository } from '@/yk/repo/core/repository-provider';
-import type { Winner } from '@/yk/repo/core/repositories';
+import type { Verdict } from '@/yk/repo/core/repositories';
 import { findJudgeByCodeName } from '@/yk/judges';
 import { useRepositoriesOptional } from '@/yk/repo/core/repository-context';
 
 export type JudgementState =
   | { status: 'idle'; data: null; error: null }
   | { status: 'loading'; data: null; error: null }
-  | { status: 'success'; data: Winner; error: null }
+  | { status: 'success'; data: Verdict; error: null }
   | { status: 'error'; data: null; error: Error };
 
 export function useJudgement(

--- a/src/test/msw.ts
+++ b/src/test/msw.ts
@@ -27,7 +27,13 @@ export const handlers = [
     });
   }),
   http.get('/api/battle/judgement', () => {
-    return HttpResponse.json('DRAW');
+    return HttpResponse.json({
+      winner: 'DRAW',
+      reason: 'api',
+      rng: 0.5,
+      judgeCode: 'MSW',
+      powerDiff: 0,
+    });
   }),
 ];
 

--- a/src/yk/judge.d.ts
+++ b/src/yk/judge.d.ts
@@ -1,9 +1,9 @@
 /**
  * Judge class for determining the winner between two fighters.
  */
-import type { Battle } from 'src/types/types';
+import type { Battle } from '../types/types';
 import type { PlayMode } from './play-mode';
-import type { Winner } from '@/yk/repo/core/repositories';
+import type { Verdict } from './repo/core/repositories';
 export declare class Judge {
   id: string;
   name: string;
@@ -15,5 +15,5 @@ export declare class Judge {
   }: {
     battle: Battle;
     mode: PlayMode;
-  }): Promise<Winner>;
+  }): Promise<Verdict>;
 }

--- a/src/yk/judge.test.ts
+++ b/src/yk/judge.test.ts
@@ -47,7 +47,7 @@ describe('Judge', () => {
           battle,
           mode: demoMode,
         });
-        expect(result).toBe('YONO');
+        expect(result.winner).toBe('YONO');
       });
 
       it('should return "KOMAE" when komaePower is greater than yonoPower', async () => {
@@ -57,7 +57,7 @@ describe('Judge', () => {
           battle,
           mode: demoMode,
         });
-        expect(result).toBe('KOMAE');
+        expect(result.winner).toBe('KOMAE');
       });
 
       it('should return "DRAW" when powers are equal', async () => {
@@ -67,7 +67,7 @@ describe('Judge', () => {
           battle,
           mode: demoMode,
         });
-        expect(result).toBe('DRAW');
+        expect(result.winner).toBe('DRAW');
       });
 
       it('should handle edge case with zero powers', async () => {
@@ -77,49 +77,49 @@ describe('Judge', () => {
           battle,
           mode: demoMode,
         });
-        expect(result).toBe('DRAW');
+        expect(result.winner).toBe('DRAW');
       });
 
       it('should handle edge case with negative powers', async () => {
         const judge = new Judge('id', 'T', 'T');
-        const result1 = await judge.determineWinner({
+        const resA = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(-10), dummyNeta(-5)),
           mode: demoMode,
         });
-        expect(result1).toBe('KOMAE');
+        expect(resA.winner).toBe('KOMAE');
 
-        const result2 = await judge.determineWinner({
+        const resB = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(-5), dummyNeta(-10)),
           mode: demoMode,
         });
-        expect(result2).toBe('YONO');
+        expect(resB.winner).toBe('YONO');
 
-        const result3 = await judge.determineWinner({
+        const resC = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(-5), dummyNeta(-5)),
           mode: demoMode,
         });
-        expect(result3).toBe('DRAW');
+        expect(resC.winner).toBe('DRAW');
       });
 
       it('should handle decimal powers', async () => {
         const judge = new Judge('id', 'T', 'T');
-        const result1 = await judge.determineWinner({
+        const res1 = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(50.5), dummyNeta(50.4)),
           mode: demoMode,
         });
-        expect(result1).toBe('YONO');
+        expect(res1.winner).toBe('YONO');
 
         const result2 = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(50.4), dummyNeta(50.5)),
           mode: demoMode,
         });
-        expect(result2).toBe('KOMAE');
+        expect(result2.winner).toBe('KOMAE');
 
         const result3 = await judge.determineWinner({
           battle: dummyBattle(dummyNeta(50.5), dummyNeta(50.5)),
           mode: demoMode,
         });
-        expect(result3).toBe('DRAW');
+        expect(result3.winner).toBe('DRAW');
       });
 
       it('should be an instance async method now', () => {
@@ -136,7 +136,7 @@ describe('Judge', () => {
           ),
           mode: demoMode,
         });
-        expect(result1).toBe('YONO');
+        expect(result1.winner).toBe('YONO');
 
         const result2 = await judge.determineWinner({
           battle: dummyBattle(
@@ -145,7 +145,7 @@ describe('Judge', () => {
           ),
           mode: demoMode,
         });
-        expect(result2).toBe('KOMAE');
+        expect(result2.winner).toBe('KOMAE');
 
         const result3 = await judge.determineWinner({
           battle: dummyBattle(
@@ -154,7 +154,7 @@ describe('Judge', () => {
           ),
           mode: demoMode,
         });
-        expect(result3).toBe('DRAW');
+        expect(result3.winner).toBe('DRAW');
       });
     });
   });

--- a/src/yk/judge.ts
+++ b/src/yk/judge.ts
@@ -5,7 +5,7 @@
 import type { Battle } from 'src/types/types';
 import type { PlayMode } from './play-mode';
 import { getJudgementRepository } from '@/yk/repo/core/repository-provider';
-import type { Winner } from '@/yk/repo/core/repositories';
+import type { Verdict } from '@/yk/repo/core/repositories';
 
 export class Judge {
   id: string;
@@ -25,7 +25,7 @@ export class Judge {
   }: {
     battle: Battle;
     mode: PlayMode;
-  }): Promise<Winner> {
+  }): Promise<Verdict> {
     // Delegate to repository layer (handles delays and strategy per mode)
     const repo = await getJudgementRepository(mode);
     // Propagate judge identifier to allow per-judge individuality downstream

--- a/src/yk/repo/api/repositories.api.d.ts
+++ b/src/yk/repo/api/repositories.api.d.ts
@@ -1,7 +1,7 @@
 import type {
   BattleReportRepository,
   JudgementRepository,
-  Winner,
+  Verdict,
 } from '@/yk/repo/core/repositories';
 import type { Battle, Neta } from '@/types/types';
 import { type DelayOption } from '../core/delay-utils';
@@ -84,5 +84,5 @@ export declare class ApiJudgementRepository implements JudgementRepository {
     opts?: {
       signal?: AbortSignal;
     },
-  ): Promise<Winner>;
+  ): Promise<Verdict>;
 }

--- a/src/yk/repo/api/repositories.api.test.ts
+++ b/src/yk/repo/api/repositories.api.test.ts
@@ -28,7 +28,7 @@ describe('api mode repositories (msw)', () => {
 
   it('fetches judgement from API', async () => {
     const repo = await getJudgementRepository(apiMode);
-    const winner = await repo.determineWinner({
+    const verdict = await repo.determineWinner({
       battle: {
         id: 'msw-battle-1',
         title: 't',
@@ -52,6 +52,6 @@ describe('api mode repositories (msw)', () => {
       },
       judge: { id: 'api-test-judge', name: 'Test', codeName: 'TEST' },
     });
-    expect(winner).toBe('DRAW');
+    expect(verdict.winner).toBe('DRAW');
   });
 });

--- a/src/yk/repo/api/repositories.api.ts
+++ b/src/yk/repo/api/repositories.api.ts
@@ -1,7 +1,7 @@
 import type {
   BattleReportRepository,
   JudgementRepository,
-  Winner,
+  Verdict,
 } from '@/yk/repo/core/repositories';
 import type { Battle, Neta } from '@/types/types';
 import { applyDelay, type DelayOption } from '../core/delay-utils';
@@ -102,7 +102,7 @@ export class ApiJudgementRepository implements JudgementRepository {
       judge: { id: string; name: string; codeName: string };
     },
     opts?: { signal?: AbortSignal },
-  ): Promise<Winner> {
+  ): Promise<Verdict> {
     await applyDelay(this.delay, opts?.signal);
     // For now, API endpoint is mode-agnostic in this client; include judge id in idempotency key.
     const reqKey = JSON.stringify({
@@ -111,7 +111,7 @@ export class ApiJudgementRepository implements JudgementRepository {
     });
     const idempotencyKey = fnv1a32(reqKey);
     const path = `/battle/judgement`;
-    return getWithRetry<Winner>(this.api, path, opts?.signal, {
+    return getWithRetry<Verdict>(this.api, path, opts?.signal, {
       'X-Idempotency-Key': idempotencyKey,
     });
   }

--- a/src/yk/repo/core/repositories.d.ts
+++ b/src/yk/repo/core/repositories.d.ts
@@ -1,9 +1,8 @@
 import type { Battle, Neta } from '../../../types/types';
 import type { PlayMode } from '../../../yk/play-mode';
 export type { Battle, Neta, PlayMode };
-export type Winner = 'YONO' | 'KOMAE' | 'DRAW';
 export type Verdict = {
-  winner: Winner;
+  winner: 'YONO' | 'KOMAE' | 'DRAW';
   reason: 'bias-hit' | 'power' | 'api' | 'default' | 'near-tie';
   judgeCode?: string;
   rng?: number;

--- a/src/yk/repo/core/repositories.d.ts
+++ b/src/yk/repo/core/repositories.d.ts
@@ -1,15 +1,15 @@
-import type { Battle, Neta } from '@/types/types';
-import type { PlayMode } from '@/yk/play-mode';
+import type { Battle, Neta } from '../../../types/types';
+import type { PlayMode } from '../../../yk/play-mode';
 export type { Battle, Neta, PlayMode };
-/**
- * Winner result for a battle judgement
- *
- * Represents the possible outcomes of a Yono vs Komae battle.
- * - `'YONO'`: Yono wins the battle
- * - `'KOMAE'`: Komae wins the battle
- * - `'DRAW'`: Battle ends in a tie
- */
 export type Winner = 'YONO' | 'KOMAE' | 'DRAW';
+export type Verdict = {
+  winner: Winner;
+  reason: 'bias-hit' | 'power' | 'api' | 'default' | 'near-tie';
+  judgeCode?: string;
+  rng?: number;
+  powerDiff?: number;
+  confidence?: number;
+};
 export type JudgeIdentity = {
   id: string;
   name: string;
@@ -88,12 +88,12 @@ export interface BattleReportRepository {
  * - Separates battle outcome logic from battle generation
  * - Enables different judging strategies per PlayMode
  * - Supports both synchronous and asynchronous judging
- * - Provides consistent Winner type across implementations
+ * - Provides consistent Verdict type across implementations
  *
  * **Usage Pattern**:
  * ```typescript
  * const repository = await getJudgementRepository(mode);
- * const winner = await repository.determineWinner({
+ * const verdict = await repository.determineWinner({
  *   battle,
  *   judge: { id: 'j-1', name: 'Judge Judy', codeName: 'JUDY' },
  * });
@@ -104,7 +104,7 @@ export interface BattleReportRepository {
  * - {@link ApiJudgementRepository} - Remote API-based judging
  * - {@link DemoJaJudgementRepository} - Fixed demo outcomes
  *
- * @see {@link Winner} for possible battle outcomes
+ * @see {@link Verdict} for result shape and possible outcomes
  * @see {@link PlayMode} for mode-specific judging rules
  */
 export interface JudgementRepository {
@@ -122,7 +122,7 @@ export interface JudgementRepository {
    * @param input.judge Identity of the judge performing the evaluation
    * @param options Optional configuration
    * @param options.signal AbortSignal for cancelling long-running judgements
-   * @returns Promise resolving to battle Winner
+  * @returns Promise resolving to battle Verdict
    * @throws Error if judgement fails or is cancelled
    */
   determineWinner(
@@ -133,7 +133,7 @@ export interface JudgementRepository {
     options?: {
       signal?: AbortSignal;
     },
-  ): Promise<Winner>;
+  ): Promise<Verdict>;
 }
 /**
  * ScenarioRepository

--- a/src/yk/repo/core/repositories.ts
+++ b/src/yk/repo/core/repositories.ts
@@ -15,6 +15,26 @@ export type { Battle, Neta, PlayMode };
 export type Winner = 'YONO' | 'KOMAE' | 'DRAW';
 
 /**
+ * Verdict
+ *
+ * Rich result for a battle judgement. Contains the winner and
+ * lightweight metadata useful for UX, logging, and testing.
+ */
+export type Verdict = {
+  winner: Winner;
+  /** high-level reason of decision path */
+  reason: 'bias-hit' | 'power' | 'api' | 'default' | 'near-tie';
+  /** normalized judge code, if available */
+  judgeCode?: string;
+  /** random number sampled in [0,1), if applicable */
+  rng?: number;
+  /** yono.power - komae.power for quick inspection */
+  powerDiff?: number;
+  /** optional confidence score 0..1 for future models */
+  confidence?: number;
+};
+
+/**
  * JudgeIdentity
  *
  * Lightweight identity DTO for a Judge. Prefer passing this across
@@ -101,12 +121,12 @@ export interface BattleReportRepository {
  * - Separates battle outcome logic from battle generation
  * - Enables different judging strategies per PlayMode
  * - Supports both synchronous and asynchronous judging
- * - Provides consistent Winner type across implementations
+ * - Provides consistent Verdict type across implementations
  *
  * **Usage Pattern**:
  * ```typescript
  * const repository = await getJudgementRepository(mode);
- * const winner = await repository.determineWinner({
+ * const verdict = await repository.determineWinner({
  *   battle,
  *   judge: { id: 'j-1', name: 'Judge Judy', codeName: 'JUDY' },
  * });
@@ -117,7 +137,7 @@ export interface BattleReportRepository {
  * - {@link ApiJudgementRepository} - Remote API-based judging
  * - {@link DemoJaJudgementRepository} - Fixed demo outcomes
  *
- * @see {@link Winner} for possible battle outcomes
+ * @see {@link Verdict} for result detail and possible outcomes
  * @see {@link PlayMode} for mode-specific judging rules
  */
 export interface JudgementRepository {
@@ -135,7 +155,7 @@ export interface JudgementRepository {
    * @param input.judge Identity of the judge performing the evaluation
    * @param options Optional configuration
    * @param options.signal AbortSignal for cancelling long-running judgements
-   * @returns Promise resolving to battle Winner
+   * @returns Promise resolving to battle Verdict
    * @throws Error if judgement fails or is cancelled
    */
   determineWinner(
@@ -144,7 +164,7 @@ export interface JudgementRepository {
       judge: JudgeIdentity;
     },
     options?: { signal?: AbortSignal },
-  ): Promise<Winner>;
+  ): Promise<Verdict>;
 }
 
 /**

--- a/src/yk/repo/core/repositories.ts
+++ b/src/yk/repo/core/repositories.ts
@@ -5,23 +5,13 @@ import type { PlayMode } from '@/yk/play-mode';
 export type { Battle, Neta, PlayMode };
 
 /**
- * Winner result for a battle judgement
- *
- * Represents the possible outcomes of a Yono vs Komae battle.
- * - `'YONO'`: Yono wins the battle
- * - `'KOMAE'`: Komae wins the battle
- * - `'DRAW'`: Battle ends in a tie
- */
-export type Winner = 'YONO' | 'KOMAE' | 'DRAW';
-
-/**
  * Verdict
  *
  * Rich result for a battle judgement. Contains the winner and
  * lightweight metadata useful for UX, logging, and testing.
  */
 export type Verdict = {
-  winner: Winner;
+  winner: 'YONO' | 'KOMAE' | 'DRAW';
   /** high-level reason of decision path */
   reason: 'bias-hit' | 'power' | 'api' | 'default' | 'near-tie';
   /** normalized judge code, if available */

--- a/src/yk/repo/core/repository-context.ts
+++ b/src/yk/repo/core/repository-context.ts
@@ -64,7 +64,7 @@ export const RepoContext = createContext<RepoContextValue | null>(null);
  *
  *   const generateBattle = async () => {
  *     const battle = await battleReport.generateReport();
- *     const winner = await judgement.determineWinner({
+ *     const verdict = await judgement.determineWinner({
  *       mode,
  *       yono: battle.yono,
  *       komae: battle.komae

--- a/src/yk/repo/core/repository-provider.d.ts
+++ b/src/yk/repo/core/repository-provider.d.ts
@@ -2,7 +2,7 @@ import type {
   BattleReportRepository,
   JudgementRepository,
 } from './repositories';
-import type { PlayMode } from '@/yk/play-mode';
+import type { PlayMode } from '../../play-mode';
 /**
  * Factory function for creating BattleReportRepository instances based on PlayMode.
  *
@@ -87,7 +87,7 @@ export declare function getBattleReportRepository(
  * const localJudge = await getJudgementRepository();
  *
  * // Usage in battle resolution
- * const winner = await judge.determineWinner({
+ * const verdict = await judge.determineWinner({
  *   mode,
  *   yono: battle.yono,
  *   komae: battle.komae

--- a/src/yk/repo/core/repository-provider.demo-de.test.ts
+++ b/src/yk/repo/core/repository-provider.demo-de.test.ts
@@ -27,7 +27,7 @@ describe('repository-provider mapping for demo-de', () => {
       description: '',
       enabled: true,
     });
-    const winner = await judge.determineWinner(
+    const verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -55,6 +55,6 @@ describe('repository-provider mapping for demo-de', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('YONO');
+    expect(verdict.winner).toBe('YONO');
   });
 });

--- a/src/yk/repo/core/repository-provider.demo-en.test.ts
+++ b/src/yk/repo/core/repository-provider.demo-en.test.ts
@@ -29,7 +29,7 @@ describe('repository-provider mapping for demo-en', () => {
       enabled: true,
     });
     // Use trivial battle to assert algorithm and that call works
-    const winner = await judge.determineWinner(
+    const verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -57,6 +57,6 @@ describe('repository-provider mapping for demo-en', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('YONO');
+    expect(verdict.winner).toBe('YONO');
   });
 });

--- a/src/yk/repo/core/repository-provider.ts
+++ b/src/yk/repo/core/repository-provider.ts
@@ -430,12 +430,12 @@ function withJudgementTiming<T extends JudgementRepository>(repo: T): T {
 }
 
 // ---- request collapsing + short-term memoization for judgements ----
-type Winner = import('./repositories').Winner;
+type Verdict = import('./repositories').Verdict;
 // reserved for future use
 
 type CacheEntry = {
-  promise: Promise<Winner> | null;
-  value?: Winner;
+  promise: Promise<Verdict> | null;
+  value?: Verdict;
   expiresAt: number;
 };
 
@@ -614,7 +614,7 @@ function withJudgementCollapsing<T extends JudgementRepository>(
           if (options.signal.aborted) {
             throw new DOMException('Aborted', 'AbortError');
           }
-          return new Promise<Winner>((resolve, reject) => {
+          return new Promise<Verdict>((resolve, reject) => {
             const onAbort = () =>
               reject(new DOMException('Aborted', 'AbortError'));
             options.signal!.addEventListener('abort', onAbort, { once: true });
@@ -643,7 +643,7 @@ function withJudgementCollapsing<T extends JudgementRepository>(
             value,
             expiresAt: Date.now() + ttl,
           });
-          return value as Winner;
+          return value as Verdict;
         })
         .catch((err) => {
           // clear entry on error so future attempts can retry
@@ -662,7 +662,7 @@ function withJudgementCollapsing<T extends JudgementRepository>(
         if (options.signal.aborted) {
           throw new DOMException('Aborted', 'AbortError');
         }
-        return new Promise<Winner>((resolve, reject) => {
+        return new Promise<Verdict>((resolve, reject) => {
           const onAbort = () =>
             reject(new DOMException('Aborted', 'AbortError'));
           options.signal!.addEventListener('abort', onAbort, { once: true });

--- a/src/yk/repo/demo/common/repositories.demo-common.ts
+++ b/src/yk/repo/demo/common/repositories.demo-common.ts
@@ -2,6 +2,7 @@ import type {
   BattleReportRepository,
   JudgementRepository,
   Winner,
+  Verdict,
 } from '@/yk/repo/core/repositories';
 import type { Battle } from '@/types/types';
 import { uid } from '@/lib/id';
@@ -60,10 +61,12 @@ export class DemoJudgementRepository implements JudgementRepository {
       judge: { id: string; name: string; codeName: string };
     },
     options?: { signal?: AbortSignal },
-  ): Promise<Winner> {
+  ): Promise<Verdict> {
     await applyDelay(this.delay, options?.signal);
     const { yono, komae } = input.battle;
-    if (yono.power === komae.power) return 'DRAW';
-    return yono.power > komae.power ? 'YONO' : 'KOMAE';
+    const powerDiff = yono.power - komae.power;
+    const winner: Winner =
+      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+    return { winner, reason: 'power', powerDiff };
   }
 }

--- a/src/yk/repo/demo/common/repositories.demo-common.ts
+++ b/src/yk/repo/demo/common/repositories.demo-common.ts
@@ -64,8 +64,8 @@ export class DemoJudgementRepository implements JudgementRepository {
     await applyDelay(this.delay, options?.signal);
     const { yono, komae } = input.battle;
     const powerDiff = yono.power - komae.power;
-  const winner: 'YONO' | 'KOMAE' | 'DRAW' =
-    powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+    const winner: 'YONO' | 'KOMAE' | 'DRAW' =
+      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
     return { winner, reason: 'power', powerDiff };
   }
 }

--- a/src/yk/repo/demo/common/repositories.demo-common.ts
+++ b/src/yk/repo/demo/common/repositories.demo-common.ts
@@ -1,7 +1,6 @@
 import type {
   BattleReportRepository,
   JudgementRepository,
-  Winner,
   Verdict,
 } from '@/yk/repo/core/repositories';
 import type { Battle } from '@/types/types';
@@ -65,8 +64,8 @@ export class DemoJudgementRepository implements JudgementRepository {
     await applyDelay(this.delay, options?.signal);
     const { yono, komae } = input.battle;
     const powerDiff = yono.power - komae.power;
-    const winner: Winner =
-      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+  const winner: 'YONO' | 'KOMAE' | 'DRAW' =
+    powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
     return { winner, reason: 'power', powerDiff };
   }
 }

--- a/src/yk/repo/demo/demo-de/repositories.demo-de.test.ts
+++ b/src/yk/repo/demo/demo-de/repositories.demo-de.test.ts
@@ -46,7 +46,7 @@ describe('demo-de repositories', () => {
     };
 
     // YONO wins
-    let winner = await judge.determineWinner(
+    let verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -69,10 +69,10 @@ describe('demo-de repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('YONO');
+    expect(verdict.winner).toBe('YONO');
 
     // KOMAE wins
-    winner = await judge.determineWinner(
+    verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -95,10 +95,10 @@ describe('demo-de repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('KOMAE');
+    expect(verdict.winner).toBe('KOMAE');
 
     // DRAW
-    winner = await judge.determineWinner(
+    verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -121,6 +121,6 @@ describe('demo-de repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('DRAW');
+    expect(verdict.winner).toBe('DRAW');
   });
 });

--- a/src/yk/repo/demo/demo-en/repositories.demo-en.test.ts
+++ b/src/yk/repo/demo/demo-en/repositories.demo-en.test.ts
@@ -46,7 +46,7 @@ describe('demo-en repositories', () => {
     };
 
     // YONO wins
-    let winner = await judge.determineWinner(
+    let verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -69,10 +69,10 @@ describe('demo-en repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('YONO');
+    expect(verdict.winner).toBe('YONO');
 
     // KOMAE wins
-    winner = await judge.determineWinner(
+    verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -95,10 +95,10 @@ describe('demo-en repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('KOMAE');
+    expect(verdict.winner).toBe('KOMAE');
 
     // DRAW
-    winner = await judge.determineWinner(
+    verdict = await judge.determineWinner(
       {
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
         battle: {
@@ -121,6 +121,6 @@ describe('demo-en repositories', () => {
       },
       { signal: undefined },
     );
-    expect(winner).toBe('DRAW');
+    expect(verdict.winner).toBe('DRAW');
   });
 });

--- a/src/yk/repo/demo/demo-ja/repositories.demo-ja.test.ts
+++ b/src/yk/repo/demo/demo-ja/repositories.demo-ja.test.ts
@@ -109,12 +109,12 @@ describe('Demo repositories with delay support', () => {
         },
       };
 
-      const winner = await repo.determineWinner({
+      const verdict = await repo.determineWinner({
         battle,
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
       });
 
-      expect(winner).toBe('YONO');
+      expect(verdict.winner).toBe('YONO');
     });
 
     it('returns DRAW when powers are equal', async () => {
@@ -142,12 +142,12 @@ describe('Demo repositories with delay support', () => {
         },
       };
 
-      const winner = await repo.determineWinner({
+      const verdict = await repo.determineWinner({
         battle,
         judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
       });
 
-      expect(winner).toBe('DRAW');
+      expect(verdict.winner).toBe('DRAW');
     });
 
     it('supports AbortSignal in determineWinner', async () => {
@@ -181,7 +181,7 @@ describe('Demo repositories with delay support', () => {
         },
       };
 
-      const winner = await repo.determineWinner(
+      const verdict = await repo.determineWinner(
         {
           battle,
           judge: { id: 't-judge', name: 'Test Judge', codeName: 'TEST' },
@@ -189,7 +189,7 @@ describe('Demo repositories with delay support', () => {
         { signal: controller.signal },
       );
 
-      expect(winner).toBe('YONO');
+      expect(verdict.winner).toBe('YONO');
     });
   });
 });

--- a/src/yk/repo/historical-evidences/repositories.historical-evidences.judgement.test.ts
+++ b/src/yk/repo/historical-evidences/repositories.historical-evidences.judgement.test.ts
@@ -37,10 +37,10 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoForced.determineWinner({ battle, judge: judgeO }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
     await expect(
       repoForced.determineWinner({ battle, judge: judgeU }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
 
     const repoFallback = new HistoricalEvidencesJudgementRepository({
       rng: () => 0.2,
@@ -51,19 +51,19 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
         battle: makeBattle(40, 60),
         judge: judgeO,
       }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(60, 40),
         judge: judgeU,
       }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(50, 50),
         judge: judgeO,
       }),
-    ).resolves.toBe('DRAW');
+    ).resolves.toMatchObject({ winner: 'DRAW' });
   });
 
   it('S/C: 20% forces KOMAE; otherwise compare by power', async () => {
@@ -75,10 +75,10 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoForced.determineWinner({ battle: makeBattle(90, 10), judge: judgeS }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
     await expect(
       repoForced.determineWinner({ battle: makeBattle(10, 90), judge: judgeC }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
 
     const repoFallback = new HistoricalEvidencesJudgementRepository({
       rng: () => 0.2,
@@ -88,19 +88,19 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
         battle: makeBattle(40, 60),
         judge: judgeS,
       }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(60, 40),
         judge: judgeC,
       }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(50, 50),
         judge: judgeS,
       }),
-    ).resolves.toBe('DRAW');
+    ).resolves.toMatchObject({ winner: 'DRAW' });
   });
 
   it('KK: 90% forces KOMAE; otherwise compare by power', async () => {
@@ -111,7 +111,7 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoForced.determineWinner({ battle: makeBattle(99, 1), judge: judgeKK }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
 
     const repoFallback = new HistoricalEvidencesJudgementRepository({
       rng: () => 0.9,
@@ -121,19 +121,19 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
         battle: makeBattle(60, 40),
         judge: judgeKK,
       }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(40, 60),
         judge: judgeKK,
       }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
     await expect(
       repoFallback.determineWinner({
         battle: makeBattle(50, 50),
         judge: judgeKK,
       }),
-    ).resolves.toBe('DRAW');
+    ).resolves.toMatchObject({ winner: 'DRAW' });
   });
 
   it('Unknown code: no forcing; compare by power', async () => {
@@ -141,13 +141,13 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     const repo = new HistoricalEvidencesJudgementRepository({ rng: () => 0 });
     await expect(
       repo.determineWinner({ battle: makeBattle(60, 40), judge: judgeX }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
     await expect(
       repo.determineWinner({ battle: makeBattle(40, 60), judge: judgeX }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
     await expect(
       repo.determineWinner({ battle: makeBattle(50, 50), judge: judgeX }),
-    ).resolves.toBe('DRAW');
+    ).resolves.toMatchObject({ winner: 'DRAW' });
   });
 
   it('Judge codeName is trimmed and case-insensitive', async () => {
@@ -162,7 +162,7 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoO.determineWinner({ battle: makeBattle(1, 99), judge: judge_o }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
 
     // r < 0.2 => KOMAE for S
     const repoS = new HistoricalEvidencesJudgementRepository({
@@ -170,7 +170,7 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoS.determineWinner({ battle: makeBattle(99, 1), judge: judge_s }),
-    ).resolves.toBe('KOMAE');
+    ).resolves.toMatchObject({ winner: 'KOMAE' });
 
     // r >= 0.9 => fallback for K
     const repoK = new HistoricalEvidencesJudgementRepository({
@@ -178,7 +178,7 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
     });
     await expect(
       repoK.determineWinner({ battle: makeBattle(60, 40), judge: judge_k }),
-    ).resolves.toBe('YONO');
+    ).resolves.toMatchObject({ winner: 'YONO' });
   });
 
   it('Caches by (battleId, judge.id) in historical-research mode (RNG fixed for pair)', async () => {
@@ -200,6 +200,6 @@ describe('HistoricalEvidencesJudgementRepository probabilistic bias with power f
       battle: { ...makeBattle(99, 1), id: 'test-battle' },
       judge,
     });
-    expect(second).toBe(first);
+    expect(second.winner).toBe(first.winner);
   });
 });

--- a/src/yk/repo/historical-evidences/repositories.historical-evidences.ts
+++ b/src/yk/repo/historical-evidences/repositories.historical-evidences.ts
@@ -3,7 +3,6 @@ import type { Battle, Neta } from '@/types/types';
 import type {
   BattleReportRepository,
   JudgementRepository,
-  Winner,
   Verdict,
 } from '@/yk/repo/core/repositories';
 import { z } from 'zod';
@@ -238,12 +237,12 @@ export class HistoricalEvidencesJudgementRepository
    *
    * Contract:
    * - Inputs: Battle (yono, komae) and Judge (id, name, codeName)
-   * - Output: Winner string literal: 'YONO' | 'KOMAE' | 'DRAW'
+   * - Output: 'YONO' | 'KOMAE' | 'DRAW'
    *
    * @param input.battle The battle context containing both neta and power values.
    * @param input.judge The judging entity identity (codeName is used).
    * @param options.signal AbortSignal to cancel the operation.
-   * @returns The decided Winner.
+   * @returns The decided literal winner value.
    */
   async determineWinner(
     input: {
@@ -281,7 +280,7 @@ export class HistoricalEvidencesJudgementRepository
  * @param komae KOMAE side neta
  * @returns 'YONO' when yono.power > komae.power, 'KOMAE' when less, otherwise 'DRAW'.
  */
-function decideByPower(yono: Neta, komae: Neta): Winner {
+function decideByPower(yono: Neta, komae: Neta): 'YONO' | 'KOMAE' | 'DRAW' {
   if (yono.power > komae.power) return 'YONO';
   if (yono.power < komae.power) return 'KOMAE';
   return 'DRAW';
@@ -300,14 +299,14 @@ function decideByPower(yono: Neta, komae: Neta): Winner {
  * @param r Random number in [0, 1) from RNG injection.
  * @param yono YONO neta
  * @param komae KOMAE neta
- * @returns Winner after applying probability and fallback rules.
+ * @returns Literal winner value after applying rules.
  */
 function computeWinnerWithProbAndFallback(
   judgeCode: string,
   r: number,
   yono: Neta,
   komae: Neta,
-): Winner {
+): 'YONO' | 'KOMAE' | 'DRAW' {
   const code = (judgeCode ?? '').trim().toUpperCase();
   switch (code) {
     case 'O':

--- a/src/yk/repo/mock/repositories.fake.d.ts
+++ b/src/yk/repo/mock/repositories.fake.d.ts
@@ -1,6 +1,9 @@
-import type { PlayMode } from '@/yk/play-mode';
-import type { JudgementRepository, Winner } from '../core/repositories';
-import type { Battle } from '@/types/types';
+import type {
+  JudgementRepository,
+  Verdict,
+  JudgeIdentity,
+  Battle,
+} from '../core/repositories';
 import { type DelayOption } from '../core/delay-utils';
 export declare class FakeJudgementRepository implements JudgementRepository {
   private delay?;
@@ -8,11 +11,10 @@ export declare class FakeJudgementRepository implements JudgementRepository {
   determineWinner(
     input: {
       battle: Battle;
-      mode: PlayMode;
-      extra?: Record<string, unknown>;
+      judge: JudgeIdentity;
     },
     options?: {
       signal?: AbortSignal;
     },
-  ): Promise<Winner>;
+  ): Promise<Verdict>;
 }

--- a/src/yk/repo/mock/repositories.fake.test.ts
+++ b/src/yk/repo/mock/repositories.fake.test.ts
@@ -40,7 +40,7 @@ describe('Fake repositories - delay capping', () => {
       },
       judge: { id: 'fake-judge-1', name: 'Fake', codeName: 'FAKE' },
     });
-    expect(result).toBe('YONO');
+    expect(result.winner).toBe('YONO');
     expect(warnSpy).toHaveBeenCalled();
     const messages = warnSpy.mock.calls.map((c) => String(c[0]));
     expect(
@@ -74,7 +74,7 @@ describe('Fake repositories - delay capping', () => {
       },
       judge: { id: 'fake-judge-2', name: 'Fake', codeName: 'FAKE' },
     });
-    expect(res).toBe('KOMAE');
+    expect(res.winner).toBe('KOMAE');
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/yk/repo/mock/repositories.fake.ts
+++ b/src/yk/repo/mock/repositories.fake.ts
@@ -1,8 +1,4 @@
-import type {
-  JudgementRepository,
-  Winner,
-  Verdict,
-} from '../core/repositories';
+import type { JudgementRepository, Verdict } from '../core/repositories';
 import type { Battle } from '@/types/types';
 import { applyDelay, type DelayOption } from '../core/delay-utils';
 
@@ -22,8 +18,8 @@ export class FakeJudgementRepository implements JudgementRepository {
     const yono = input.battle.yono;
     const komae = input.battle.komae;
     const powerDiff = yono.power - komae.power;
-    const winner: Winner =
-      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+    const winner: 'YONO' | 'KOMAE' | 'DRAW' =
+    powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
     return { winner, reason: 'power', powerDiff };
   }
 }

--- a/src/yk/repo/mock/repositories.fake.ts
+++ b/src/yk/repo/mock/repositories.fake.ts
@@ -19,7 +19,7 @@ export class FakeJudgementRepository implements JudgementRepository {
     const komae = input.battle.komae;
     const powerDiff = yono.power - komae.power;
     const winner: 'YONO' | 'KOMAE' | 'DRAW' =
-    powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
     return { winner, reason: 'power', powerDiff };
   }
 }

--- a/src/yk/repo/mock/repositories.fake.ts
+++ b/src/yk/repo/mock/repositories.fake.ts
@@ -1,4 +1,8 @@
-import type { JudgementRepository, Winner } from '../core/repositories';
+import type {
+  JudgementRepository,
+  Winner,
+  Verdict,
+} from '../core/repositories';
 import type { Battle } from '@/types/types';
 import { applyDelay, type DelayOption } from '../core/delay-utils';
 
@@ -13,12 +17,13 @@ export class FakeJudgementRepository implements JudgementRepository {
       judge: { id: string; name: string; codeName: string };
     },
     options?: { signal?: AbortSignal },
-  ): Promise<Winner> {
+  ): Promise<Verdict> {
     await applyDelay(this.delay, options?.signal);
     const yono = input.battle.yono;
     const komae = input.battle.komae;
-    if (yono.power > komae.power) return 'YONO';
-    if (yono.power < komae.power) return 'KOMAE';
-    return 'DRAW';
+    const powerDiff = yono.power - komae.power;
+    const winner: Winner =
+      powerDiff === 0 ? 'DRAW' : powerDiff > 0 ? 'YONO' : 'KOMAE';
+    return { winner, reason: 'power', powerDiff };
   }
 }


### PR DESCRIPTION
Summary
- NetaView: remove top padding on Card to attach image to the very top (pt-0). Keeps other spacing unchanged.
- ConsiderationsAndJudgments: align comments/docs to p = 4/7 to match implementation; no runtime behavior changed.

Verification
- Ran unit tests: 23 passed, 1 skipped (86 total).
- Visual: image sits flush to the card top; hover scale stays clipped by rounded corners.

Notes
- If further tightening between image and content is desired, consider adding gap-0 on Card or adjusting CardContent padding.
